### PR TITLE
Fix #6 and get up-to-date elapsedTime

### DIFF
--- a/include/MRContent.h
+++ b/include/MRContent.h
@@ -1,0 +1,8 @@
+@interface MRContentItemMetadata : NSObject
+@property CGFloat calculatedPlaybackPosition;
+@end
+
+@interface MRContentItem : NSObject
+@property (retain) MRContentItemMetadata *metadata;
+- (instancetype)initWithNowPlayingInfo:(NSDictionary *)nowPlayingInfo;
+@end


### PR DESCRIPTION
Seems like I was able to fix the elapsedTime being inaccurate by adding in a hack from [this reddit thread](https://www.reddit.com/r/jailbreakdevelopers/comments/ogneoy/help_how_do_i_get_the_current_elapsed_time_of_the/) with the minimum changes necessary to make it macOS compatible.

Works for getting up to date elapsed time for me in Safari / YouTube Music, without pausing/unpausing.