### PR TITLE
Feature: 'seek' subcommand to navigate playback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and Store Artifact
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-11, macos-12, macos-13, macos-14]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: make
+
+      - name: Run test
+        run: |
+          output=$(./nowplaying-cli get-raw)
+          if [ $? -ne 0 ]; then
+            echo "Command failed"
+            exit 1
+          fi
+          if [ "$output" != "(null)" ]; then
+            echo "Unexpected output: $output"
+            exit 1
+          fi
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nowplaying-cli-${{ matrix.os }}
+          path: ./nowplaying-cli

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ mv nowplaying-cli ~/.local/bin
 | play | play the currently playing media regardless of current state |
 | pause | pause the currently playing media regardless of current state |
 | togglePlayPause | toggle play/pause based on current state |
+| seek <seconds> | seek to a specific time in the currently playing media |
 | next | skip to next track | 
 | previous | go to previous track |
 


### PR DESCRIPTION
This adds a new subcommand 'seek', taking a number (`double`) in seconds of the
desired target seek time.

```bash
nowplaying-cli seek 60 # Seeks 1 minute into any currently playing/paused media
```

This makes use of the `MRMediaRemoteSetElapsedTime` function which completes after media information has been retrieved, so the early termination has been updated to handle this case.

Tested with TIDAL, Chrome, and VLC.

---

This PR additionally adds a basic Github Actions workflow to build, run, and archive the artifact on macOS 11 through 14. As Github Actions are not currently enabled for this repo, an example of them running can be seen here:
https://github.com/Stealthii/nowplaying-cli/actions/runs/8713583230

After this is merged they will run against the `main` branch, and any open PRs.