### PR TITLE
Add support to skip forward and rewind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 nowplaying-cli
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ mv nowplaying-cli ~/.local/bin
 | pause | pause the currently playing media regardless of current state |
 | togglePlayPause | toggle play/pause based on current state |
 | seek <seconds> | seek to a specific time in the currently playing media |
+| skip <seconds> | skip forward or rewind track |
 | next | skip to next track | 
 | previous | go to previous track |
 


### PR DESCRIPTION
Might be useful when combined with Apple Script to globally rewind and fast forward tracks, e.g.

```shell
nowplaying-cli skip 10
nowplaying-cli skip -10
```