### PR TITLE
fix: load helper script and dylib from installed prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ OBJC = clang
 CFLAGS = -O3
 FRAMEWORKS = -framework Cocoa
 INCLUDES = -I./include
+PREFIX ?= /usr/local
+BIN_DIR = $(PREFIX)/bin
+LIB_DIR = $(PREFIX)/lib/nowplaying-cli
+SHARE_DIR = $(PREFIX)/share/nowplaying-cli
 
 MINI_DIR = src/mediaremote-mini
 MINI_BUILD_DIR = build/mediaremote-mini
@@ -29,6 +33,18 @@ $(MINI_DYLIB): $(MINI_SRC) $(MINI_HEADERS)
 
 nowplaying-cli: src/nowplaying.mm $(MINI_DYLIB)
 	$(CXX) $(CFLAGS) $(FRAMEWORKS) $(INCLUDES) $< -o $@
+
+install: all
+	mkdir -p $(DESTDIR)$(BIN_DIR) $(DESTDIR)$(LIB_DIR) $(DESTDIR)$(SHARE_DIR)/scripts
+	cp nowplaying-cli $(DESTDIR)$(BIN_DIR)/nowplaying-cli
+	cp $(MINI_DYLIB) $(DESTDIR)$(LIB_DIR)/MediaRemoteMini.dylib
+	cp scripts/mediaremote-mini.pl $(DESTDIR)$(SHARE_DIR)/scripts/mediaremote-mini.pl
+	chmod 755 $(DESTDIR)$(BIN_DIR)/nowplaying-cli $(DESTDIR)$(SHARE_DIR)/scripts/mediaremote-mini.pl
+
+uninstall:
+	rm -f $(DESTDIR)$(BIN_DIR)/nowplaying-cli
+	rm -f $(DESTDIR)$(LIB_DIR)/MediaRemoteMini.dylib
+	rm -f $(DESTDIR)$(SHARE_DIR)/scripts/mediaremote-mini.pl
 
 clean:
 	rm -f nowplaying-cli

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ brew install nowplaying-cli
 
 ### Build from source
 
-Clone the repository and run `make` to build the binary. You can then move the binary to your desired location.
+Clone the repository and run `make` to build the binary. If you want to install it system-wide, use `make install` so the helper script and dylib are installed alongside it.
 ```bash
-make
-mv nowplaying-cli ~/.local/bin
+sudo make install
 ```
 
 ## Usage

--- a/src/nowplaying.mm
+++ b/src/nowplaying.mm
@@ -228,43 +228,19 @@ static NSString *GetExecutableDir(void) {
     return [path stringByDeletingLastPathComponent];
 }
 
-static NSArray<NSString *> *HelperPrefixCandidates(void) {
-    NSMutableArray<NSString *> *candidates = [NSMutableArray array];
-    NSFileManager *fm = [NSFileManager defaultManager];
-
-    NSString *exeDir = GetExecutableDir();
-    if (exeDir) {
-        [candidates addObject:exeDir];
-        NSString *parent = [exeDir stringByDeletingLastPathComponent];
-        if (parent && ![parent isEqualToString:exeDir]) {
-            [candidates addObject:parent];
-        }
-    }
-
-    NSDictionary<NSString *, NSString *> *env = [[NSProcessInfo processInfo] environment];
-    NSString *resourceRoot = env[@"NOWPLAYING_CLI_RESOURCE_ROOT"];
-    if (resourceRoot.length > 0) {
-        [candidates addObject:resourceRoot];
-    }
-
-    NSString *prefix = env[@"NOWPLAYING_CLI_PREFIX"];
-    if (prefix.length > 0) {
-        [candidates addObject:prefix];
-    }
-
-    for (NSString *defaultPrefix in @[@"/usr/local", @"/opt/homebrew"]) {
-        if ([fm fileExistsAtPath:defaultPrefix]) {
-            [candidates addObject:defaultPrefix];
-        }
-    }
-
-    return candidates;
-}
-
 static BOOL ResolveHelperPaths(NSString **scriptPath, NSString **dylibPath) {
     NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *exeDir = GetExecutableDir();
+    if (!exeDir) return NO;
 
-    for (NSString *base in HelperPrefixCandidates()) {
+    // Search the executable's own directory and its parent.
+    NSMutableArray<NSString *> *bases = [NSMutableArray arrayWithObject:exeDir];
+    NSString *parent = [exeDir stringByDeletingLastPathComponent];
+    if (parent && ![parent isEqualToString:exeDir]) {
+        [bases addObject:parent];
+    }
+
+    for (NSString *base in bases) {
         NSArray<NSArray<NSString *> *> *layouts = @[
             @[
                 [base stringByAppendingPathComponent:@"scripts/mediaremote-mini.pl"],
@@ -279,7 +255,7 @@ static BOOL ResolveHelperPaths(NSString **scriptPath, NSString **dylibPath) {
         for (NSArray<NSString *> *layout in layouts) {
             NSString *candidateScript = layout[0];
             NSString *candidateDylib = layout[1];
-            if (![fm isExecutableFileAtPath:candidateScript]) continue;
+            if (![fm isReadableFileAtPath:candidateScript]) continue;
             if (![fm isReadableFileAtPath:candidateDylib]) continue;
 
             if (scriptPath) *scriptPath = candidateScript;

--- a/src/nowplaying.mm
+++ b/src/nowplaying.mm
@@ -228,16 +228,73 @@ static NSString *GetExecutableDir(void) {
     return [path stringByDeletingLastPathComponent];
 }
 
-static NSDictionary *ReadViaHelperBinary(void) {
+static NSArray<NSString *> *HelperPrefixCandidates(void) {
+    NSMutableArray<NSString *> *candidates = [NSMutableArray array];
     NSFileManager *fm = [NSFileManager defaultManager];
+
     NSString *exeDir = GetExecutableDir();
-    if (!exeDir) return nil;
+    if (exeDir) {
+        [candidates addObject:exeDir];
+        NSString *parent = [exeDir stringByDeletingLastPathComponent];
+        if (parent && ![parent isEqualToString:exeDir]) {
+            [candidates addObject:parent];
+        }
+    }
 
-    NSString *scriptPath = [exeDir stringByAppendingPathComponent:@"scripts/mediaremote-mini.pl"];
-    NSString *dylibPath = [exeDir stringByAppendingPathComponent:@"build/mediaremote-mini/MediaRemoteMini.dylib"];
+    NSDictionary<NSString *, NSString *> *env = [[NSProcessInfo processInfo] environment];
+    NSString *resourceRoot = env[@"NOWPLAYING_CLI_RESOURCE_ROOT"];
+    if (resourceRoot.length > 0) {
+        [candidates addObject:resourceRoot];
+    }
 
-    if (![fm isExecutableFileAtPath:scriptPath]) return nil;
-    if (![fm isReadableFileAtPath:dylibPath]) return nil;
+    NSString *prefix = env[@"NOWPLAYING_CLI_PREFIX"];
+    if (prefix.length > 0) {
+        [candidates addObject:prefix];
+    }
+
+    for (NSString *defaultPrefix in @[@"/usr/local", @"/opt/homebrew"]) {
+        if ([fm fileExistsAtPath:defaultPrefix]) {
+            [candidates addObject:defaultPrefix];
+        }
+    }
+
+    return candidates;
+}
+
+static BOOL ResolveHelperPaths(NSString **scriptPath, NSString **dylibPath) {
+    NSFileManager *fm = [NSFileManager defaultManager];
+
+    for (NSString *base in HelperPrefixCandidates()) {
+        NSArray<NSArray<NSString *> *> *layouts = @[
+            @[
+                [base stringByAppendingPathComponent:@"scripts/mediaremote-mini.pl"],
+                [base stringByAppendingPathComponent:@"build/mediaremote-mini/MediaRemoteMini.dylib"],
+            ],
+            @[
+                [base stringByAppendingPathComponent:@"share/nowplaying-cli/scripts/mediaremote-mini.pl"],
+                [base stringByAppendingPathComponent:@"lib/nowplaying-cli/MediaRemoteMini.dylib"],
+            ],
+        ];
+
+        for (NSArray<NSString *> *layout in layouts) {
+            NSString *candidateScript = layout[0];
+            NSString *candidateDylib = layout[1];
+            if (![fm isExecutableFileAtPath:candidateScript]) continue;
+            if (![fm isReadableFileAtPath:candidateDylib]) continue;
+
+            if (scriptPath) *scriptPath = candidateScript;
+            if (dylibPath) *dylibPath = candidateDylib;
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static NSDictionary *ReadViaHelperBinary(void) {
+    NSString *scriptPath = nil;
+    NSString *dylibPath = nil;
+    if (!ResolveHelperPaths(&scriptPath, &dylibPath)) return nil;
 
     NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:@"/usr/bin/perl"];


### PR DESCRIPTION
I found that when I use `make install` or simply move the built output into a bin directory, the CLI can no longer detect that music is playing.

However, if I run it directly from the build directory, it works fine.

It seems that the program depends on `MediaRemoteMini.dylib` and `mediaremote-mini.pl`, and expects to find them in the same directory as the executable. That is likely what causes the problem, so I changed the current behavior to make it work.

Here are the screenshots showing the bug.

Before:

<img width="1347" height="670" alt="Screenshot 2026-04-06 at 03 49 33" src="https://github.com/user-attachments/assets/d2751852-150d-4cbc-8898-d82467b16b94" />



After:

<img width="1580" height="716" alt="image" src="https://github.com/user-attachments/assets/350d9930-1a66-4a4f-9188-90bbfa2e1066" />
