### PR TITLE
Fix elapsedTime returning 0 on macOS 15.4+ via mediaremote-mini helper path

### DIFF
--- a/src/nowplaying.mm
+++ b/src/nowplaying.mm
@@ -159,31 +159,6 @@ static void printJSON(NSDictionary *dict) {
     }
 }
 
-// Compute the current playback position from a snapshot.
-//
-// MediaRemote reports kMRMediaRemoteNowPlayingInfoElapsedTime as a snapshot
-// captured at kMRMediaRemoteNowPlayingInfoTimestamp.  To get the live
-// position we advance the snapshot by (now - timestamp) * playbackRate.
-//
-// Falls back to the raw snapshot if timestamp is missing.
-static double computeLiveElapsedTime(NSDictionary *info) {
-    NSNumber *elapsedNum = info[@"kMRMediaRemoteNowPlayingInfoElapsedTime"];
-    if (!elapsedNum) return 0.0;
-    double elapsed = [elapsedNum doubleValue];
-
-    id timestamp = info[@"kMRMediaRemoteNowPlayingInfoTimestamp"];
-    if (![timestamp isKindOfClass:[NSDate class]]) return elapsed;
-
-    NSNumber *rateNum = info[@"kMRMediaRemoteNowPlayingInfoPlaybackRate"];
-    double rate = rateNum ? [rateNum doubleValue] : 1.0;
-    if (rate == 0.0) return elapsed;
-
-    NSTimeInterval delta = [[NSDate date] timeIntervalSinceDate:(NSDate *)timestamp];
-    if (delta < 0) return elapsed;
-
-    return elapsed + (delta * rate);
-}
-
 static id getValueForKey(NSDictionary *info, NSString *key) {
     NSObject *rawValue = [info objectForKey:key];
     if (!rawValue) return nil;
@@ -191,8 +166,6 @@ static id getValueForKey(NSDictionary *info, NSString *key) {
     if ([key isEqualToString:@"kMRMediaRemoteNowPlayingInfoArtworkData"] ||
         [key isEqualToString:@"kMRMediaRemoteNowPlayingInfoClientPropertiesData"]) {
         return [(NSData *)rawValue base64EncodedStringWithOptions:0];
-    } else if ([key isEqualToString:@"kMRMediaRemoteNowPlayingInfoElapsedTime"]) {
-        return @(computeLiveElapsedTime(info));
     }
     return rawValue;
 }

--- a/src/nowplaying.mm
+++ b/src/nowplaying.mm
@@ -380,6 +380,16 @@ static NSDictionary *LegacyInfoDictFromHelperJSON(NSDictionary *json) {
         if (date) info[@"kMRMediaRemoteNowPlayingInfoTimestamp"] = date;
     }
 
+    // Some sources (notably browsers) leave playbackRate at 1.0 when paused
+    // and only signal pause via the "playing" boolean.  Force the effective
+    // playbackRate to 0 when the source reports it as not playing, so that
+    // computeLiveElapsedTime() and consumers of `get playbackRate` see the
+    // true current state.
+    id playing = json[@"playing"];
+    if ([playing isKindOfClass:[NSNumber class]] && ![playing boolValue]) {
+        info[@"kMRMediaRemoteNowPlayingInfoPlaybackRate"] = @(0.0);
+    }
+
     return ([info count] > 0) ? info : nil;
 }
 

--- a/src/nowplaying.mm
+++ b/src/nowplaying.mm
@@ -159,6 +159,31 @@ static void printJSON(NSDictionary *dict) {
     }
 }
 
+// Compute the current playback position from a snapshot.
+//
+// MediaRemote reports kMRMediaRemoteNowPlayingInfoElapsedTime as a snapshot
+// captured at kMRMediaRemoteNowPlayingInfoTimestamp.  To get the live
+// position we advance the snapshot by (now - timestamp) * playbackRate.
+//
+// Falls back to the raw snapshot if timestamp is missing.
+static double computeLiveElapsedTime(NSDictionary *info) {
+    NSNumber *elapsedNum = info[@"kMRMediaRemoteNowPlayingInfoElapsedTime"];
+    if (!elapsedNum) return 0.0;
+    double elapsed = [elapsedNum doubleValue];
+
+    id timestamp = info[@"kMRMediaRemoteNowPlayingInfoTimestamp"];
+    if (![timestamp isKindOfClass:[NSDate class]]) return elapsed;
+
+    NSNumber *rateNum = info[@"kMRMediaRemoteNowPlayingInfoPlaybackRate"];
+    double rate = rateNum ? [rateNum doubleValue] : 1.0;
+    if (rate == 0.0) return elapsed;
+
+    NSTimeInterval delta = [[NSDate date] timeIntervalSinceDate:(NSDate *)timestamp];
+    if (delta < 0) return elapsed;
+
+    return elapsed + (delta * rate);
+}
+
 static id getValueForKey(NSDictionary *info, NSString *key) {
     NSObject *rawValue = [info objectForKey:key];
     if (!rawValue) return nil;
@@ -167,9 +192,7 @@ static id getValueForKey(NSDictionary *info, NSString *key) {
         [key isEqualToString:@"kMRMediaRemoteNowPlayingInfoClientPropertiesData"]) {
         return [(NSData *)rawValue base64EncodedStringWithOptions:0];
     } else if ([key isEqualToString:@"kMRMediaRemoteNowPlayingInfoElapsedTime"]) {
-        MRContentItem *contentItem = [[objc_getClass("MRContentItem") alloc]
-                                      initWithNowPlayingInfo:(__bridge NSDictionary *)info];
-        return @(contentItem.metadata.calculatedPlaybackPosition);
+        return @(computeLiveElapsedTime(info));
     }
     return rawValue;
 }
@@ -344,6 +367,17 @@ static NSDictionary *LegacyInfoDictFromHelperJSON(NSDictionary *json) {
         } else {
             info[legacyKey] = value;
         }
+    }
+
+    // Parse the helper's ISO-8601 "timestamp" into an NSDate so that
+    // computeLiveElapsedTime() can advance the elapsedTime snapshot.
+    id ts = json[@"timestamp"];
+    if ([ts isKindOfClass:[NSString class]]) {
+        static NSISO8601DateFormatter *fmt = nil;
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{ fmt = [[NSISO8601DateFormatter alloc] init]; });
+        NSDate *date = [fmt dateFromString:(NSString *)ts];
+        if (date) info[@"kMRMediaRemoteNowPlayingInfoTimestamp"] = date;
     }
 
     return ([info count] > 0) ? info : nil;


### PR DESCRIPTION
## Summary

On main, `nowplaying-cli get elapsedTime` returns `0` for any source served by the mediaremote-mini helper path (added in #31) on macOS 15.4+ / 26. This makes the elapsed-time output usable again, and adds two related cleanups.

## Background

`getValueForKey()` for `kMRMediaRemoteNowPlayingInfoElapsedTime` calls into the private MRContentItem class to read `calculatedPlaybackPosition` (introduced by #11). Two issues:

1. On macOS 15.4+ / 26 the class lookup silently returns 0 — even when reached.
2. The mediaremote-mini helper added in #31 short-circuits the framework path, so the private-class workaround is never reached. The helper's JSON already carries `elapsedTime`, but `LegacyInfoDictFromHelperJSON()` then funnels everything back through the same broken `getValueForKey()` branch → 0.

Net effect on current main: `get elapsedTime` returns `0` for everything.

## Changes (`src/nowplaying.mm`)

1. **Remove the broken MRContentItem call** in `getValueForKey()`. `get elapsedTime` now returns the raw `kMRMediaRemoteNowPlayingInfoElapsedTime` from the dict, which is what every other key already does.

2. **Parse the helper's `timestamp` field** (ISO-8601 string) into `kMRMediaRemoteNowPlayingInfoTimestamp` (NSDate) in `LegacyInfoDictFromHelperJSON()`. This makes `get-raw` expose the timestamp on the helper path for parity with the legacy framework path, so callers that want to do their own `elapsed + (now - timestamp) * rate` extrapolation have the inputs.

3. **Honor `playing: false` from the helper.** Some sources (notably browsers like Firefox) leave `playbackRate: 1` even when paused, signalling pause only via the top-level `playing` boolean. When the helper reports `playing: false`, force the dict's `kMRMediaRemoteNowPlayingInfoPlaybackRate` to 0 so `get playbackRate` and `get-raw` reflect reality.

### A note on live extrapolation

An earlier iteration of this PR also added `computeLiveElapsedTime()` that returned `elapsed + (now - timestamp) * rate` for `get elapsedTime`. Empirical capture against Firefox on macOS 26.4.1 showed that MediaRemote does **not** refresh `timestamp` on play/pause transitions — it only updates on its own periodic heartbeat (~every few seconds during continuous playback). So after a pause/resume, `(now - timestamp)` includes the pause duration, and extrapolation over-counts by that amount; each pause cycle accumulates another pause-duration of drift until the next heartbeat corrects it.

Fixing this in a single stateless invocation is not possible — from a lone snapshot we cannot recover how much of `(now - timestamp)` was playback vs paused. The mediaremote-mini library acknowledges the same limitation: its `elapsedTimeNow` field is documented as *"just a rough estimation, meant to be used for convenience"*. The final commit on this branch removes the extrapolation; `get elapsedTime` returns the snapshot. Sub-heartbeat precision is lost (~2s granularity during playback), correctness across pause/resume is gained.

If a caller wants live extrapolation, `get-raw` now exposes both `Timestamp` and `PlaybackRate` so they can compute it themselves with whatever drift-handling policy fits their use case.

## Verification

macOS 26.4.1, Firefox playing audio. **Before** this PR:

```
$ nowplaying-cli get elapsedTime
0
```

**After** this PR:

```
$ nowplaying-cli get elapsedTime
281.66873358928467
$ nowplaying-cli get-raw
{
  "kMRMediaRemoteNowPlayingInfoElapsedTime" : 281.66873358928467,
  "kMRMediaRemoteNowPlayingInfoPlaybackRate" : 1,
  "kMRMediaRemoteNowPlayingInfoTimestamp" : 1778780754,
  ...
}
```

Paused (helper reports `"playing": false, "playbackRate": 1`):

```
$ nowplaying-cli get-raw | grep PlaybackRate
  "kMRMediaRemoteNowPlayingInfoPlaybackRate" : 0,
$ nowplaying-cli get elapsedTime  # stable across calls
281.66873358928467
```

Pause/resume cycles drive the snapshot's `elapsedTime` to stable values that do not drift — verified by driving play/pause via the CLI itself and observing that the reported elapsed value matches what the source publishes at its next heartbeat.

## Test plan

- [x] `make` builds cleanly
- [x] `./nowplaying-cli get-raw` smoke test (matches existing CI)
- [x] `get elapsedTime` returns a sensible snapshot value (not 0) for a Firefox source
- [x] `get-raw` includes `kMRMediaRemoteNowPlayingInfoTimestamp` on the helper path
- [x] `get playbackRate` returns 0 when the helper reports `playing: false` despite `playbackRate: 1` in the source data
- [x] Multiple pause/resume cycles do not drift the reported elapsedTime
- [ ] CI matrix (macos-14 / macos-15 / macos-26) — GitHub Actions